### PR TITLE
fix flake8 error (ignore): C901 'doc_watch' is too complex (10)

### DIFF
--- a/pavement.py.tpl
+++ b/pavement.py.tpl
@@ -209,7 +209,7 @@ def coverage():
                      TESTS_DIRECTORY])
 
 
-@task
+@task  # NOQA
 def doc_watch():
     ('Watch for changes in the Sphinx documentation and rebuild when '
      'changed.')


### PR DESCRIPTION
Running `paver test_all` after creating a vanilla Python project from template results in:

```
pavement.py:224:1: C901 'doc_watch' is too complex (10)
```

This patch marks the `doc_watch` task to be ignored by flake8.
