### PR TITLE
small cleanup: sort imports by alphabetical order, add blank line betwee...

### DIFF
--- a/GENERATE.py
+++ b/GENERATE.py
@@ -4,10 +4,11 @@
 # properly substituted.
 
 from __future__ import print_function
+
 import os
-import sys
 import os.path
 from string import Template
+import sys
 
 sys.path.append('my_module')
 # Can't use `from my_module import metadata' since `__init__.py' is templated.

--- a/docs/source/conf.py.tpl
+++ b/docs/source/conf.py.tpl
@@ -13,8 +13,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/my_module/__init__.py.tpl
+++ b/my_module/__init__.py.tpl
@@ -2,6 +2,8 @@
 """
 
 from $package import metadata
+
+
 __version__ = metadata.version
 __author__ = metadata.authors[0]
 __license__ = metadata.license

--- a/my_module/main.py.tpl
+++ b/my_module/main.py.tpl
@@ -3,8 +3,10 @@
 """
 
 from __future__ import print_function
-import sys
+
 import argparse
+import sys
+
 from $package import metadata
 
 

--- a/pavement.py.tpl
+++ b/pavement.py.tpl
@@ -1,9 +1,11 @@
 # -*- coding: utf-8; -*-
 
 from __future__ import print_function
+
 import os
 import sys
 import time
+
 import subprocess
 
 ## Python 2.6 subprocess.check_output compatibility. Thanks Greg Hewgill!


### PR DESCRIPTION
...n `__future__` imports, standard modules, third-party modules, and own modules
