### PR TITLE
Move current directory to front of sys.path

### DIFF
--- a/setup.py.tpl
+++ b/setup.py.tpl
@@ -32,7 +32,7 @@ except ImportError:
     pass
 
 # Add the current directory to the module search path.
-sys.path.append('.')
+sys.path.insert(0, os.path.abspath('.'))
 
 ## Constants
 CODE_DIRECTORY = '$package'


### PR DESCRIPTION
Errors are thrown if another module named `config` is in the path.

Moving this to the front ensure that the project's config.py is the one that gets imported.