### PR TITLE
fixed assertion with err instead out

### DIFF
--- a/tests/test_main.py.tpl
+++ b/tests/test_main.py.tpl
@@ -33,6 +33,6 @@ class TestMain(object):
             main(['progname', versionarg])
         out, err = capsys.readouterr()
         # Should print out version.
-        assert err == '{0} {1}\n'.format(metadata.project, metadata.version)
+        assert out == '{0} {1}\n'.format(metadata.project, metadata.version)
         # Should exit with zero return code.
         assert exc_info.value.code == 0


### PR DESCRIPTION
Simple fix. In test_version it was asserted the err variable would be equal with actual value, instead out variable. So tests were failing for both test parameters: '-V', '--version